### PR TITLE
increase time out to 120s for htsget->sanger

### DIFF
--- a/tester.py
+++ b/tester.py
@@ -64,7 +64,7 @@ def htsget_api(
     with open(filename, "wb") as tmp:
         htsget.get(
             url, tmp, reference_name=reference_name, reference_md5=reference_md5,
-            start=start, end=end, data_format=data_format)
+            start=start, end=end, data_format=data_format, timeout=120)
 
 
 def htsget_cli(
@@ -74,7 +74,7 @@ def htsget_cli(
     Runs the htsget CLI program. Assumes that htsget has been installed and the
     CLI program is in PATH.
     """
-    cmd = ["htsget", url, "-O", filename]
+    cmd = ["htsget", url, "-O", filename, "--timeout", "120"]
     if reference_name is not None:
         cmd.extend(["-r", str(reference_name)])
     if start is not None:


### PR DESCRIPTION
I was running the tester and seems most of things finish in 20s or less... The waiting bit that was giving the timeout was around 12s. As I understand the error, the connection was timing out waiting for anything (first bytes) to come back. I think Sanger server is special in the sense that it may delay the response (even headers) for a while. 120s sounds reasonable to me. But I'm only changing the Sanger lines. If things look good maybe it can become the default in your io.py and then we can drop this change? It was very good decision to expose the time out! Thanks!